### PR TITLE
Feature Add - Cosmwasm state sync support

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -736,6 +736,17 @@ func NewTeritoriApp(
 	app.SetBeginBlocker(app.BeginBlocker)
 	app.SetEndBlocker(app.EndBlocker)
 
+	// Ensure that state sync delivers the cosmwasm directory as well
+
+	if manager := app.SnapshotManager(); manager != nil {
+		err = manager.RegisterExtensions(
+			wasmkeeper.NewWasmSnapshotter(app.CommitMultiStore(), &app.WasmKeeper),
+		)
+		if err != nil {
+			panic("failed to register snapshot extension: " + err.Error())
+		}
+	}
+
 	if loadLatest {
 		if err := app.LoadLatestVersion(); err != nil {
 			tmos.Exit(fmt.Sprintf("failed to load latest version: %s", err))


### PR DESCRIPTION
Currently, the `wasm` directory is not sent along when state syncing.

I've spoke with Lydia over at ChihuahuaChain, as they just implemented a fix for this themselves.  I examined their code implementation of it, and adapted it to fit Teritori's code base.

Code testing:
I created a node to act as a RPC State sync.  I manually uploaded a fresh WASM dir and state synced the node.  I waited for it to catch up and verified that it had made a snapshot in the snapshot folder.

I then created another node.  I specifically had it talk to the test node for state sync and highly restricted it's snapshot finding window.
```
rpc_servers = "localhost:26657,localhost:26657"
trust_height = 605000
trust_hash = "7FA9AA10046B744E8A0D9E6B60A90043E640EE6CE2FAB74A50E7CE163BB7F141"
trust_period = "24h0m0s"
```

This test client node found the snapshot from the test rpc/state sync server, downloaded it, and began syncing.  No app hash errors were experienced.  WASM data folder was verified, existed, and contained the latest wasm contracts.

